### PR TITLE
🛡️ Sentinel: Enforce length limits on tab group titles

### DIFF
--- a/background.js
+++ b/background.js
@@ -56,7 +56,8 @@ async function saveStateToCloud() {
 
       if (validTabs.length > 0) {
         payload.push({
-          title: group.title || "Untitled Group",
+          // Security: Truncate title to 50 chars to prevent storage bloat
+          title: (group.title || "Untitled Group").substring(0, 50),
           color: group.color || "grey",
           tabs: validTabs.map(t => t.url)
         });

--- a/background.logic.js
+++ b/background.logic.js
@@ -42,7 +42,8 @@ export async function saveStateToCloud() {
 
       if (validTabs.length > 0) {
         payload.push({
-          title: group.title || "Untitled Group",
+          // Security: Truncate title to 50 chars to prevent storage bloat
+          title: (group.title || "Untitled Group").substring(0, 50),
           color: group.color || "grey",
           tabs: validTabs.map(t => t.url)
         });

--- a/background.logic.test.js
+++ b/background.logic.test.js
@@ -74,6 +74,34 @@ describe('background.logic', () => {
         },
       });
     });
+
+    it('should truncate long group titles to 50 characters', async () => {
+      browser.storage.local.get.mockResolvedValue({ device_id: 'test_id' });
+      const longTitle = 'A'.repeat(100);
+      const expectedTitle = 'A'.repeat(50);
+      browser.tabGroups.query.mockResolvedValue([
+        { id: 1, title: longTitle, color: 'blue' },
+      ]);
+      browser.tabs.query.mockResolvedValue([
+        { url: 'https://example.com/1', groupId: 1 },
+      ]);
+
+      await saveStateToCloud();
+
+      expect(browser.storage.sync.set).toHaveBeenCalledWith({
+        state_test_id: {
+          timestamp: expect.any(Number),
+          deviceName: null,
+          groups: [
+            {
+              title: expectedTitle,
+              color: 'blue',
+              tabs: ['https://example.com/1'],
+            },
+          ],
+        },
+      });
+    });
   });
 
   describe('restoreFromCloud', () => {


### PR DESCRIPTION
🛡️ Sentinel: Enforce length limits on tab group titles

**Vulnerability:**
Tab group titles were previously synced without length limits. A malicious actor or a bug could create groups with massive titles, exhausting the limited `browser.storage.sync` quota (typically ~100KB total), causing a Denial of Service for the sync feature.

**Fix:**
- Updated `saveStateToCloud` in `background.js` and `background.logic.js` to truncate group titles to 50 characters.
- Added a unit test in `background.logic.test.js` to verify truncation behavior.

**Verification:**
- Run `npm test` to verify the new test case `should truncate long group titles to 50 characters` passes.

---
*PR created automatically by Jules for task [5627260785909603531](https://jules.google.com/task/5627260785909603531) started by @sudhir-asuracore*