### PR TITLE
🛡️ Sentinel: Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Core business logic is duplicated between `background.js` (production) and `background.logic.js` (testing), creating a risk where security patches are only applied to one.
 **Learning:** `background.js` does not import from `background.logic.js` but reimplements the same functions.
 **Prevention:** Always verify if a logic change needs to be applied to multiple files by searching for similar function names or logic patterns. Ideally, refactor to share code, but for now, double-patching is required.
+
+## 2026-01-22 - [Manifest V3 CSP Defense]
+**Vulnerability:** Missing Content Security Policy (CSP) in `manifest.json` leaves the extension vulnerable to potential XSS attacks and unauthorized resource loading.
+**Learning:** Manifest V3 extensions should explicitly define a strict CSP. External resources (like images from CDNs) must be explicitly allowed.
+**Prevention:** Define `content_security_policy` with `script-src 'self'`, `object-src 'none'`, and specific allowlists for `img-src` or `style-src` only when necessary.

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,9 @@
     ],
     "type": "module"
   },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'; img-src 'self' https://storage.ko-fi.com;"
+  },
   "action": {
     "default_title": "Tab Group Syncer",
     "default_popup": "popup.html",


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

## Vulnerability
Missing Content Security Policy (CSP) in `manifest.json`. While Manifest V3 enforces a baseline CSP, explicitly defining it allows for tighter control and defense-in-depth against XSS and unauthorized resource loading.

## Impact
Without strict CSP, future changes or vulnerabilities might allow loading of malicious scripts or resources.

## Fix
Added `content_security_policy` to `manifest.json`:
```json
"content_security_policy": {
  "extension_pages": "script-src 'self'; object-src 'none'; img-src 'self' https://storage.ko-fi.com;"
}
```

## Verification
1. Verified `manifest.json` syntax.
2. Ran `npm test` to ensure no regressions.
3. Verified that `https://storage.ko-fi.com` is used in `popup.html` and is whitelisted.

---
*PR created automatically by Jules for task [12758873747190534387](https://jules.google.com/task/12758873747190534387) started by @sudhir-asuracore*