### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content Security Policy

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,9 @@
     "tabGroups",
     "storage"
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' https://storage.ko-fi.com"
+  },
   "background": {
     "scripts": [
       "background.js"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing Content Security Policy (CSP) in manifest.json.
🎯 Impact: While Manifest V3 has secure defaults, explicitly defining a CSP is a defense-in-depth best practice. It prevents accidental inclusion of insecure resources and strictly whitelists allowed external assets (Ko-fi image).
🔧 Fix: Added `content_security_policy` to `manifest.json` with strict rules for scripts and objects, while allowing inline styles (required for UI) and the specific Ko-fi image source.
✅ Verification:
- `npm run build` passes.
- `npm test` passes.
- Verified valid JSON structure.
- Confirmed `style-src` and `img-src` match usage in `popup.html` and `popup.js`.

---
*PR created automatically by Jules for task [2611460226609291533](https://jules.google.com/task/2611460226609291533) started by @sudhir-asuracore*