### PR TITLE
🛡️ Sentinel: Enforce title length limit on sync restore

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Core business logic is duplicated between `background.js` (production) and `background.logic.js` (testing), creating a risk where security patches are only applied to one.
 **Learning:** `background.js` does not import from `background.logic.js` but reimplements the same functions.
 **Prevention:** Always verify if a logic change needs to be applied to multiple files by searching for similar function names or logic patterns. Ideally, refactor to share code, but for now, double-patching is required.
+
+## 2026-01-22 - [Untrusted Sync Storage Input]
+**Vulnerability:** Title length limits were enforced on write but not on read. A compromised sync storage or malicious client could inject excessively long titles, potentially causing DoS or UI issues on other clients.
+**Learning:** Data from `browser.storage.sync` must be treated as untrusted input. Just because we write it safely doesn't mean it stays safe.
+**Prevention:** Re-validate and sanitize all data read from sync storage (e.g., truncate titles again) before using it in privileged APIs or UI.

--- a/background.js
+++ b/background.js
@@ -210,8 +210,11 @@ async function syncGroupsFromRemote(groupsToSync) {
       // Security: Validate color to prevent crashes or API errors
       const safeColor = VALID_COLORS.includes(remoteGroup.color) ? remoteGroup.color : 'grey';
 
+      // Security: Truncate title
+      const safeTitle = remoteGroup.title.substring(0, MAX_TITLE_LENGTH);
+
       await browser.tabGroups.update(targetGroupId, {
-        title: remoteGroup.title,
+        title: safeTitle,
         color: safeColor
       });
     }

--- a/background.logic.js
+++ b/background.logic.js
@@ -123,8 +123,11 @@ export async function restoreFromCloud(snapshotKey, selectedGroups) {
       // Security: Validate color
       const safeColor = VALID_COLORS.includes(remoteGroup.color) ? remoteGroup.color : 'grey';
 
+      // Security: Truncate title
+      const safeTitle = remoteGroup.title.substring(0, MAX_TITLE_LENGTH);
+
       await browser.tabGroups.update(targetGroupId, { 
-        title: remoteGroup.title, 
+        title: safeTitle,
         color: safeColor
       });
     }

--- a/background.logic.test.js
+++ b/background.logic.test.js
@@ -125,5 +125,29 @@ describe('background.logic', () => {
       expect(browser.tabs.group).toHaveBeenCalledWith({ tabIds: 123 });
       expect(browser.tabGroups.update).toHaveBeenCalledWith(1, { title: 'Group 1', color: 'blue' });
     });
+
+    it('should truncate group titles that exceed MAX_TITLE_LENGTH', async () => {
+      const snapshotKey = 'state_remote_id';
+      const longTitle = 'a'.repeat(150);
+      const expectedTitle = 'a'.repeat(100);
+      const selectedGroups = [longTitle];
+
+      browser.storage.sync.get.mockResolvedValue({
+        [snapshotKey]: {
+          groups: [
+            { title: longTitle, color: 'blue', tabs: ['https://example.com/new'] },
+          ],
+        },
+      });
+      browser.tabGroups.query.mockResolvedValue([]);
+      browser.tabs.create.mockResolvedValue({ id: 123 });
+      browser.tabs.group.mockResolvedValue(1);
+      browser.tabGroups.update.mockResolvedValue({});
+      browser.tabs.query.mockResolvedValue([]);
+
+      await restoreFromCloud(snapshotKey, selectedGroups);
+
+      expect(browser.tabGroups.update).toHaveBeenCalledWith(1, { title: expectedTitle, color: 'blue' });
+    });
   });
 });


### PR DESCRIPTION
Sentinel 🛡️ identified a security enhancement opportunity: data read from `browser.storage.sync` was not being sanitized for length limits, unlike data written to it. This change enforces the 100-character limit on group titles when restoring from the cloud, preventing potential issues from compromised or malicious sync data.

Changes:
- Modified `background.js`: Truncate `remoteGroup.title` in `syncGroupsFromRemote`.
- Modified `background.logic.js`: Truncate `remoteGroup.title` in `restoreFromCloud`.
- Modified `background.logic.test.js`: Added a test case to verify truncation works as expected.
- Updated `.jules/sentinel.md`: Recorded the vulnerability and learning.


---
*PR created automatically by Jules for task [7594082547361475363](https://jules.google.com/task/7594082547361475363) started by @sudhir-asuracore*