### PR TITLE
🛡️ Sentinel: [security improvement] Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Core business logic is duplicated between `background.js` (production) and `background.logic.js` (testing), creating a risk where security patches are only applied to one.
 **Learning:** `background.js` does not import from `background.logic.js` but reimplements the same functions.
 **Prevention:** Always verify if a logic change needs to be applied to multiple files by searching for similar function names or logic patterns. Ideally, refactor to share code, but for now, double-patching is required.
+
+## 2026-01-22 - [Content Security Policy in MV3]
+**Vulnerability:** Missing Content Security Policy (CSP) in `manifest.json` allows potential execution of malicious scripts or loading of unsafe resources.
+**Learning:** Manifest V3 enforces a default CSP, but explicit definitions are crucial for "Defense in Depth", especially for restricting object sources and defining allowed image sources (e.g., specific CDNs). Inline styles often require `'unsafe-inline'` in extensions.
+**Prevention:** Explicitly define `content_security_policy` in `manifest.json` with `script-src 'self'`, `object-src 'none'`, and strict `img-src` whitelists.

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,9 @@
       "strict_min_version": "120.0"
     }
   },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://storage.ko-fi.com; object-src 'none';"
+  },
   "permissions": [
     "tabs",
     "tabGroups",


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 Vulnerability: Missing Content Security Policy (CSP) in `manifest.json`.
🎯 Impact: While Manifest V3 has defaults, lacking an explicit CSP reduces defense-in-depth against XSS and allows potentially unsafe resource loading (like objects/plugins).
🔧 Fix: Added a strict CSP to `manifest.json` that:
  - Restricts scripts to `'self'`.
  - Disallows objects (`object-src 'none'`).
  - Whitelists images from `'self'` and the used Ko-fi CDN.
  - Allows inline styles (required for UI).
✅ Verification:
  - Validated `manifest.json` syntax.
  - Ran `npm test` to ensure no regressions.
  - Ran `npm run build` to verify packaging.

---
*PR created automatically by Jules for task [17834444763879828710](https://jules.google.com/task/17834444763879828710) started by @sudhir-asuracore*