### PR TITLE
🛡️ Sentinel: [HIGH] Enforce title length limits on sync restore

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Core business logic is duplicated between `background.js` (production) and `background.logic.js` (testing), creating a risk where security patches are only applied to one.
 **Learning:** `background.js` does not import from `background.logic.js` but reimplements the same functions.
 **Prevention:** Always verify if a logic change needs to be applied to multiple files by searching for similar function names or logic patterns. Ideally, refactor to share code, but for now, double-patching is required.
+
+## 2026-01-22 - [Untrusted Sync Storage]
+**Vulnerability:** Data restored from sync storage (e.g., group titles) was assumed to be safe because it was sanitized on save, but it can be tampered with or come from compromised clients.
+**Learning:** Sync storage is an untrusted boundary. Any data read from `browser.storage.sync` must be re-sanitized before use in privileged APIs or UI.
+**Prevention:** Apply sanitization (truncation, type checking) immediately upon reading data from storage, before passing it to business logic.

--- a/background.js
+++ b/background.js
@@ -210,8 +210,11 @@ async function syncGroupsFromRemote(groupsToSync) {
       // Security: Validate color to prevent crashes or API errors
       const safeColor = VALID_COLORS.includes(remoteGroup.color) ? remoteGroup.color : 'grey';
 
+      // Security: Truncate title to prevent storage exhaustion or DoS
+      const safeTitle = String(remoteGroup.title || "Untitled Group").substring(0, MAX_TITLE_LENGTH);
+
       await browser.tabGroups.update(targetGroupId, {
-        title: remoteGroup.title,
+        title: safeTitle,
         color: safeColor
       });
     }

--- a/background.logic.js
+++ b/background.logic.js
@@ -123,8 +123,11 @@ export async function restoreFromCloud(snapshotKey, selectedGroups) {
       // Security: Validate color
       const safeColor = VALID_COLORS.includes(remoteGroup.color) ? remoteGroup.color : 'grey';
 
+      // Security: Truncate title to prevent storage exhaustion or DoS
+      const safeTitle = String(remoteGroup.title || "Untitled Group").substring(0, MAX_TITLE_LENGTH);
+
       await browser.tabGroups.update(targetGroupId, { 
-        title: remoteGroup.title, 
+        title: safeTitle,
         color: safeColor
       });
     }

--- a/background.security_fix.test.js
+++ b/background.security_fix.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import { restoreFromCloud } from './background.logic.js';
+
+// Mock the entire utils.js module
+jest.mock('./utils.js', () => ({
+  normalizeUrl: jest.fn((url) => url.replace(/\/$/, '')),
+  VALID_COLORS: ['blue', 'red', 'green', 'orange', 'yellow', 'purple', 'pink', 'cyan', 'grey'],
+  MAX_TITLE_LENGTH: 100
+}));
+
+// Mock crypto.randomUUID if not available
+if (!global.crypto) {
+  global.crypto = {};
+}
+if (!global.crypto.randomUUID) {
+  global.crypto.randomUUID = () => '12345678-1234-1234-1234-1234567890ab';
+}
+
+describe('Security Fix: Unrestricted Title Length', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (!global.browser.tabGroups) {
+      global.browser.tabGroups = {
+        query: jest.fn(),
+        update: jest.fn(),
+      };
+    }
+    if (!global.browser.tabs.group) {
+      global.browser.tabs.group = jest.fn();
+    }
+  });
+
+  it('should truncate group titles from remote storage before applying', async () => {
+    const snapshotKey = 'state_remote_id';
+    const longTitle = 'a'.repeat(200); // 200 chars, well over 100 limit
+    const expectedTitle = 'a'.repeat(100);
+
+    // We select the long title to sync
+    const selectedGroups = [longTitle];
+
+    browser.storage.sync.get.mockResolvedValue({
+      [snapshotKey]: {
+        groups: [
+          { title: longTitle, color: 'blue', tabs: ['https://example.com/safe'] },
+        ],
+      },
+    });
+
+    browser.tabGroups.query.mockResolvedValue([]); // No local groups
+    browser.tabs.create.mockResolvedValue({ id: 123 });
+    browser.tabs.group.mockResolvedValue(1);
+    browser.tabGroups.update.mockResolvedValue({});
+    browser.tabs.query.mockResolvedValue([]);
+
+    await restoreFromCloud(snapshotKey, selectedGroups);
+
+    // This expectation is what we WANT to happen (truncation)
+    // Currently it will fail because it passes longTitle
+    expect(browser.tabGroups.update).toHaveBeenCalledWith(1, {
+      title: expectedTitle,
+      color: 'blue'
+    });
+  });
+});


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unrestricted group title length from sync storage could cause DoS or storage exhaustion.
🎯 Impact: An attacker or compromised client could sync a group with a massive title, potentially crashing the extension or exhausting local storage quotas upon restore.
🔧 Fix: Truncated remote group titles to `MAX_TITLE_LENGTH` (100) and cast to string before passing to `browser.tabGroups.update`.
✅ Verification: `npm test background.security_fix.test.js` passes.

---
*PR created automatically by Jules for task [309846297118250559](https://jules.google.com/task/309846297118250559) started by @sudhir-asuracore*